### PR TITLE
Changed String type xml tag to lower-case

### DIFF
--- a/XmlRpc.psm1
+++ b/XmlRpc.psm1
@@ -85,7 +85,7 @@ function ConvertTo-XmlRpcType
         # Encode string to HTML
         if ($Type -eq 'String')
         {
-            return "<value><$Type>$([System.Web.HttpUtility]::HtmlEncode($inputObject))</$Type></value>"
+            return "<value><string>$([System.Web.HttpUtility]::HtmlEncode($inputObject))</string></value>"
         }
 
         # Int32 must be casted as Int


### PR DESCRIPTION
XML tag for data type string was derived from powershell type, which is init-caps. This breaks compatibility with backends, which do a strict case-sensitive check on parameter data types used in the request