### PR TITLE
Update ConvertFrom-Xml to parse a boolean response as an int and then…

### DIFF
--- a/XmlRpc.psm1
+++ b/XmlRpc.psm1
@@ -412,7 +412,7 @@ function ConvertFrom-Xml
                         break
                     }
                     'boolean' {
-                        [bool]$InputNode.boolean
+                        [bool][int]$InputNode.boolean
                         break
                     }
                     'dateTime.iso8601' {


### PR DESCRIPTION
… a boolean, because any non-empty string resolves to True otherwise, including "0"